### PR TITLE
add dynamic routing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,43 @@
+import { useState, useEffect } from 'react';
 import './App.css'
 import { Switch, Route } from 'wouter'
 import Home from "@/pages/home"
-import ButtonDemo from "@/pages/button-demo"
-import FormDemo from "@/pages/form-demo-page"
 import NotFound from "@/pages/not-found"
 
+// Using Vite's glob import
+const pages = import.meta.glob('@/pages/*.{js,jsx,ts,tsx}');
+
 function Router() {
+  const [routes, setRoutes] = useState([] as any[]);
+
+  useEffect(() => {
+    // Load all page components
+    Promise.all(
+      Object.entries(pages).map(async ([path, importFunc]) => {
+        const module = await importFunc() as any;
+        // Convert file path to route path
+        // For example: '@/pages/About.jsx' -> '/about'
+        const routePath = '/' + path
+          .replace(/^.*\/pages\//, '')
+          .replace(/\.(js|jsx|ts|tsx)$/, '')
+          .toLowerCase();
+          
+        return {
+          path: routePath,
+          component: module.default
+        };
+      })
+    ).then(loadedRoutes => {
+      setRoutes(loadedRoutes);
+    });
+  }, []);
+
   return (
     <Switch>
       <Route path="/" component={Home} />
-      <Route path="button-demo" component={ButtonDemo} />
-      <Route path="form-demo" component={FormDemo} />
-      <Route path="/not-found" component={NotFound} />
+      {routes.map(({ path, component: Component }) => (
+        <Route key={path} path={path} component={Component} />
+      ))}
       <Route component={NotFound} />
     </Switch>
   );


### PR DESCRIPTION
Instead of adding new pages manually, any page added to `/pages` directory will automatically be imported and added to the router.

For example, if you add page `kpi-dashboard.tsx` to `/pages`, you can access it right away at `http://localhost:5173/kpi-dashboard` (assuming the server is running).

h/t to Llama and Claude